### PR TITLE
Add concept constraint for common_era_clock

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Timestamps/issues/57
+Your prepared branch: issue-57-2d008618
+Your prepared working directory: /tmp/gh-issue-solver-1757745402982
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Timestamps/issues/57
-Your prepared branch: issue-57-2d008618
-Your prepared working directory: /tmp/gh-issue-solver-1757745402982
-
-Proceed.

--- a/cpp/Platform.Timestamps/CommonEraClock.h
+++ b/cpp/Platform.Timestamps/CommonEraClock.h
@@ -62,4 +62,7 @@ namespace Platform::Timestamps
                 (std::chrono::time_point<common_era_clock, duration>(std::chrono::seconds(time)));
         }
     };
+
+    static_assert(std::chrono::is_clock_v<common_era_clock>, 
+                  "common_era_clock must satisfy the Clock concept requirements");
 } // namespace Platform::Timestamps


### PR DESCRIPTION
## Summary
- Add `static_assert(std::chrono::is_clock_v<common_era_clock>, ...)` after the `common_era_clock` definition
- Ensures `common_era_clock` satisfies the Clock concept requirements at compile time
- Addresses issue #57 by adding the requested concept constraint

## Test plan
- [x] Code compiles successfully with C++20 standard
- [x] Static assertion verifies Clock concept compliance
- [x] Existing functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #57