### PR TITLE
Make UniqueTimestampFactory thread-safe using lock-free atomic operations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Timestamps/issues/41
-Your prepared branch: issue-41-217ce4e9
-Your prepared working directory: /tmp/gh-issue-solver-1757782834468
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Timestamps/issues/41
+Your prepared branch: issue-41-217ce4e9
+Your prepared working directory: /tmp/gh-issue-solver-1757782834468
+
+Proceed.

--- a/csharp/Platform.Timestamps.Tests/UniqueTimestampFactoryTests.cs
+++ b/csharp/Platform.Timestamps.Tests/UniqueTimestampFactoryTests.cs
@@ -1,3 +1,8 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Platform.Timestamps.Tests
@@ -11,6 +16,94 @@ namespace Platform.Timestamps.Tests
             var timestamp1 = factory.Create();
             var timestamp2 = factory.Create();
             Assert.NotEqual(timestamp1, timestamp2);
+        }
+
+        [Fact]
+        public void ThreadSafetyTest()
+        {
+            var factory = new UniqueTimestampFactory();
+            var timestamps = new ConcurrentBag<Timestamp>();
+            const int taskCount = 50;
+            const int timestampsPerTask = 100;
+            
+            var tasks = new Task[taskCount];
+            for (int i = 0; i < taskCount; i++)
+            {
+                tasks[i] = Task.Run(() =>
+                {
+                    for (int j = 0; j < timestampsPerTask; j++)
+                    {
+                        timestamps.Add(factory.Create());
+                    }
+                });
+            }
+            
+            Task.WaitAll(tasks);
+            
+            var timestampList = timestamps.ToList();
+            var uniqueTimestamps = new HashSet<Timestamp>(timestampList);
+            
+            Assert.Equal(taskCount * timestampsPerTask, timestampList.Count);
+            Assert.Equal(timestampList.Count, uniqueTimestamps.Count);
+        }
+
+        [Fact]
+        public void SequentialOrderTest()
+        {
+            var factory = new UniqueTimestampFactory();
+            var timestamps = new List<Timestamp>();
+            
+            for (int i = 0; i < 1000; i++)
+            {
+                timestamps.Add(factory.Create());
+            }
+            
+            // Verify timestamps are in ascending order
+            for (int i = 1; i < timestamps.Count; i++)
+            {
+                Assert.True(timestamps[i].Ticks > timestamps[i - 1].Ticks);
+            }
+        }
+
+        [Fact]
+        public void ConcurrentSequentialOrderTest()
+        {
+            var factory = new UniqueTimestampFactory();
+            var timestamps = new ConcurrentBag<Timestamp>();
+            const int taskCount = 10;
+            const int timestampsPerTask = 50;
+            
+            var tasks = new Task[taskCount];
+            for (int i = 0; i < taskCount; i++)
+            {
+                tasks[i] = Task.Run(() =>
+                {
+                    var localTimestamps = new List<Timestamp>();
+                    for (int j = 0; j < timestampsPerTask; j++)
+                    {
+                        localTimestamps.Add(factory.Create());
+                    }
+                    
+                    // Verify local sequence is ordered
+                    for (int k = 1; k < localTimestamps.Count; k++)
+                    {
+                        Assert.True(localTimestamps[k].Ticks > localTimestamps[k - 1].Ticks);
+                    }
+                    
+                    foreach (var ts in localTimestamps)
+                    {
+                        timestamps.Add(ts);
+                    }
+                });
+            }
+            
+            Task.WaitAll(tasks);
+            
+            var allTimestamps = timestamps.ToList();
+            var uniqueTimestamps = new HashSet<Timestamp>(allTimestamps);
+            
+            Assert.Equal(taskCount * timestampsPerTask, allTimestamps.Count);
+            Assert.Equal(allTimestamps.Count, uniqueTimestamps.Count);
         }
     }
 }

--- a/csharp/Platform.Timestamps/UniqueTimestampFactory.cs
+++ b/csharp/Platform.Timestamps/UniqueTimestampFactory.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using Platform.Interfaces;
 
 namespace Platform.Timestamps
@@ -20,8 +21,15 @@ namespace Platform.Timestamps
         public Timestamp Create()
         {
             var utcTicks = (ulong)DateTime.UtcNow.Ticks;
-            _lastTicks = utcTicks > _lastTicks ? utcTicks : _lastTicks + 1;
-            return new Timestamp(_lastTicks);
+            ulong lastTicks, newTicks;
+            do
+            {
+                lastTicks = _lastTicks;
+                newTicks = utcTicks > lastTicks ? utcTicks : lastTicks + 1;
+            }
+            while (Interlocked.CompareExchange(ref _lastTicks, newTicks, lastTicks) != lastTicks);
+            
+            return new Timestamp(newTicks);
         }
     }
 }

--- a/experiments/ThreadSafetyTest.cs
+++ b/experiments/ThreadSafetyTest.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using Platform.Timestamps;
+
+namespace Platform.Timestamps.Experiments
+{
+    /// <summary>
+    /// Demonstrates the thread-safety issue with the current UniqueTimestampFactory
+    /// </summary>
+    public class ThreadSafetyTest
+    {
+        public static void DemonstrateRaceCondition()
+        {
+            var factory = new UniqueTimestampFactory();
+            var timestamps = new ConcurrentBag<Timestamp>();
+            var tasks = new Task[100];
+
+            // Create 100 concurrent tasks, each generating 10 timestamps
+            for (int i = 0; i < 100; i++)
+            {
+                tasks[i] = Task.Run(() =>
+                {
+                    for (int j = 0; j < 10; j++)
+                    {
+                        timestamps.Add(factory.Create());
+                    }
+                });
+            }
+
+            Task.WaitAll(tasks);
+
+            // Check for duplicates
+            var timestampList = new List<Timestamp>(timestamps);
+            var uniqueTimestamps = new HashSet<Timestamp>(timestampList);
+            
+            Console.WriteLine($"Total timestamps generated: {timestampList.Count}");
+            Console.WriteLine($"Unique timestamps: {uniqueTimestamps.Count}");
+            Console.WriteLine($"Duplicates found: {timestampList.Count - uniqueTimestamps.Count}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Fixed race condition in `UniqueTimestampFactory.Create()` method that could produce duplicate timestamps in multi-threaded environments
- Implemented thread-safe solution using `Interlocked.CompareExchange` with retry loop for optimal performance
- Added comprehensive test suite to validate thread-safety and timestamp uniqueness

## Technical Details
The original implementation had a race condition at `UniqueTimestampFactory.cs:23`:
```csharp
_lastTicks = utcTicks > _lastTicks ? utcTicks : _lastTicks + 1;
```

Multiple threads could read the same `_lastTicks` value simultaneously, leading to duplicate timestamps.

The solution uses lock-free atomic operations:
```csharp
ulong lastTicks, newTicks;
do
{
    lastTicks = _lastTicks;
    newTicks = utcTicks > lastTicks ? utcTicks : lastTicks + 1;
}
while (Interlocked.CompareExchange(ref _lastTicks, newTicks, lastTicks) != lastTicks);
```

## Test Coverage
Added 3 new comprehensive tests:
- **ThreadSafetyTest**: Validates uniqueness across 5,000 concurrent timestamps (50 tasks × 100 timestamps)
- **SequentialOrderTest**: Ensures timestamps maintain ascending order in single-threaded execution  
- **ConcurrentSequentialOrderTest**: Verifies ordering within concurrent execution scenarios

All tests pass, confirming the thread-safety implementation works correctly.

## Performance Impact
- Lock-free implementation provides better performance than mutex-based approaches
- Uses CPU-level atomic operations for minimal overhead
- Maintains the `[MethodImpl(MethodImplOptions.AggressiveInlining)]` optimization

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #41