### PR TITLE
Replace redundant XML documentation with inheritdoc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Timestamps/issues/18
+Your prepared branch: issue-18-3cf4d62a
+Your prepared working directory: /tmp/gh-issue-solver-1757836523763
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Timestamps/issues/18
-Your prepared branch: issue-18-3cf4d62a
-Your prepared working directory: /tmp/gh-issue-solver-1757836523763
-
-Proceed.

--- a/csharp/Platform.Timestamps/Timestamp.cs
+++ b/csharp/Platform.Timestamps/Timestamp.cs
@@ -65,37 +65,19 @@ namespace Platform.Timestamps
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static implicit operator ulong(Timestamp timestamp) => timestamp.Ticks;
 
-        /// <summary>
-        /// <para>Returns a string that represents the current Timestamp.</para>
-        /// <para>Возвращает строку, которая представляет текущую метку времени.</para>
-        /// </summary>
-        /// <returns><para>A string that represents the current Timestamp.</para><para>Строка, представляющая текущую метку времени.</para></returns>
+        /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override string ToString() => ((DateTime)this).ToString(DefaultFormat);
 
-        /// <summary>
-        /// <para>Определяет, равна ли текущая отметка времени другой отметке времени.</para>
-        /// <para>Indicates whether the current Timestamp is equal to another Timestamp.</para>
-        /// </summary>
-        /// <param name="other"><para>Other Timestamp.</para><para>Другая отметка времени.</para></param>
-        /// <returns><para>True if the current Timestamp is equal to the other Timestamp; otherwise, false.</para><para>Истину, если текущая отметка времени равна другой отметке времени; иначе ложь.</para></returns>
+        /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(Timestamp other) => Ticks == other.Ticks;
 
-        /// <summary>
-        /// <para>Determines whether the specified object is equal to the current object.</para>
-        /// <para>Определяет, равен ли указанный объект текущему объекту.</para>
-        /// </summary>
-        /// <param name="obj"><para>The object to compare with the current object.</para><para>Объект для сравнения с текущим объектом.</para></param>
-        /// <returns><para>True if the specified object is equal to the current object; otherwise, false.</para><para>Истину, если указанный объект равен текущему объекту; иначе ложь.</para></returns>
+        /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override bool Equals(object obj) => obj is Timestamp timestamp ? Equals(timestamp) : false;
 
-        /// <summary>
-        /// <para>Serves as the default hash function.</para>
-        /// <para>Служит в качестве хэш-функции по умолчанию.</para>
-        /// </summary>
-        /// <returns><para>A hash code for the current object.</para><para>Хеш-код для текущего объекта.</para></returns>
+        /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override int GetHashCode() => Ticks.GetHashCode();
 


### PR DESCRIPTION
## Summary
Replaced redundant XML documentation comments with `<inheritdoc />` for standard .NET methods that override base class methods or implement interface methods.

## Changes Made
- **ToString()**: Replaced verbose documentation with `<inheritdoc />` since it overrides `Object.ToString()`
- **Equals(object obj)**: Replaced redundant documentation with `<inheritdoc />` since it overrides `Object.Equals()`  
- **GetHashCode()**: Replaced standard documentation with `<inheritdoc />` since it overrides `Object.GetHashCode()`
- **Equals(Timestamp other)**: Replaced documentation with `<inheritdoc />` since it implements `IEquatable<T>.Equals()`

## Benefits
- Follows .NET XML documentation best practices
- Reduces code duplication and maintenance overhead
- Ensures documentation stays in sync with base class/interface definitions
- Cleaner, more concise code

## Testing
- ✅ Solution builds successfully with no errors
- ✅ All existing tests pass
- ✅ No functional changes to the code behavior

This addresses issue #18 by using `<inheritdoc />` for methods that inherit their behavior and documentation from .NET base classes.

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #18