### PR TITLE
Add internationalized XML documentation comments to test class

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Timestamps/issues/15
+Your prepared branch: issue-15-095f6c09
+Your prepared working directory: /tmp/gh-issue-solver-1757842014599
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Timestamps/issues/15
-Your prepared branch: issue-15-095f6c09
-Your prepared working directory: /tmp/gh-issue-solver-1757842014599
-
-Proceed.

--- a/csharp/Platform.Timestamps.Tests/UniqueTimestampFactoryTests.cs
+++ b/csharp/Platform.Timestamps.Tests/UniqueTimestampFactoryTests.cs
@@ -2,8 +2,16 @@ using Xunit;
 
 namespace Platform.Timestamps.Tests
 {
+    /// <summary>
+    /// <para>Represents tests for the <see cref="UniqueTimestampFactory"/> class.</para>
+    /// <para>Представляет тесты для класса <see cref="UniqueTimestampFactory"/>.</para>
+    /// </summary>
     public class UniqueTimestampFactoryTests
     {
+        /// <summary>
+        /// <para>Tests that consecutive timestamps created by the factory are unique.</para>
+        /// <para>Проверяет, что последовательные метки времени, созданные фабрикой, являются уникальными.</para>
+        /// </summary>
         [Fact]
         public void UniqueTimestampTest()
         {


### PR DESCRIPTION
## Summary
- Added bilingual XML documentation comments (English and Russian) to the `UniqueTimestampFactoryTests` class and its test method
- Followed the established pattern used throughout the linksplatform organization with `<para>` tags for each language
- Completed internationalization of code comments in the repository, as all main library classes already had proper bilingual documentation

## Changes Made
- Added XML documentation to `UniqueTimestampFactoryTests` class with both English and Russian descriptions
- Added XML documentation to `UniqueTimestampTest()` method with bilingual descriptions
- Maintained consistency with existing code style and documentation patterns

## Test Plan
- [x] Project builds successfully without errors
- [x] All existing tests continue to pass
- [x] XML documentation is properly generated with bilingual content
- [x] Code follows linksplatform documentation standards

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #15